### PR TITLE
Updated models to better define relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 package-lock.json
 client/dist
 config/config.js
-models/
+models/modelsSQL.js

--- a/models/models.js
+++ b/models/models.js
@@ -1,0 +1,128 @@
+const Sequelize = require('sequelize');
+const { config } = require('../config/config.js');
+
+// Local DB connection
+const db = new Sequelize('grounded_n_grits', 'root', config.development.password, {
+  host: '127.0.0.1',
+  dialect: 'mysql',
+  port: '3306',
+  logging: true,
+});
+
+// User schema
+const User = db.define('users', {
+  userId: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+  email: Sequelize.STRING,
+  fullName: Sequelize.STRING,
+  host: Sequelize.BOOLEAN,
+}, {
+  timestamps: false,
+});
+
+// Listing schema
+const Listing = db.define('listings', {
+  listingId: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+  listingName: Sequelize.STRING,
+  listingDescription: Sequelize.STRING,
+  minimumNights: Sequelize.INTEGER,
+  cancellationPolicy: Sequelize.TEXT,
+  hostId: {
+    type: Sequelize.INTEGER,
+    references: {
+      model: User,
+      key: 'userId',
+      deferrable: Sequelize.Deferrable.INITIALLY_DEFERRED,
+    },
+  },
+}, {
+  timestamps: false,
+});
+
+// Booking schema
+const Booking = db.define('bookings', {
+  bookingId: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+  startDate: Sequelize.DATEONLY,
+  endDate: Sequelize.DATEONLY,
+  price: Sequelize.DECIMAL(10, 2),
+  canceled: Sequelize.BOOLEAN,
+  cancellationReason: Sequelize.TEXT,
+  listingId: {
+    type: Sequelize.INTEGER,
+    references: {
+      model: Listing,
+      key: 'listingId',
+      deferrable: Sequelize.Deferrable.INITIALLY_DEFERRED,
+    },
+  },
+  guestId: {
+    type: Sequelize.INTEGER,
+    references: {
+      model: User,
+      key: 'userId',
+      deferrable: Sequelize.Deferrable.INITIALLY_DEFERRED,
+    },
+  },
+}, {
+  timestamps: false,
+});
+
+// Avaialble nights schema
+const ListingAvailableNight = db.define('listing_available_night', {
+  nightId: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+  startDate: Sequelize.DATEONLY,
+  endDate: Sequelize.DATEONLY,
+  booked: Sequelize.BOOLEAN,
+  price: Sequelize.DOUBLE(10, 2),
+  bookingId: {
+    type: Sequelize.INTEGER,
+    references: {
+      model: Booking,
+      key: 'bookingId',
+      deferrable: Sequelize.Deferrable.INITIALLY_DEFERRED,
+    },
+  },
+  listingId: {
+    type: Sequelize.INTEGER,
+    references: {
+      model: Listing,
+      key: 'listingId',
+      deferrable: Sequelize.Deferrable.INITIALLY_DEFERRED,
+    },
+  },
+  }, {
+  timestamps: false,
+});
+
+// Model relationships
+Listing.belongsTo(User, { foreignKey: 'hostId', targetKey: 'userId', constraints: false });
+User.hasMany(Listing);
+
+Booking.belongsTo(Listing, { foreignKey: 'listingId', targetKey: 'listingId', constraints: false });
+Listing.hasMany(Booking, { onDelete: 'cascade', constraints: false });
+
+Booking.belongsTo(User, { foreignKey: 'guestId', targetKey: 'userId', constraints: false });
+User.hasMany(Booking, { onDelete: 'cascade', constraints: false });
+
+ListingAvailableNight.belongsTo(Listing, { foreignKey: 'listingId', targetKey: 'listingId', constraints: false });
+ListingAvailableNight.belongsTo(Booking, { foreignKey: 'bookingId', targetKety: 'bookingId', constraints: false });
+Listing.hasMany(ListingAvailableNight);
+Booking.hasMany(ListingAvailableNight);
+
+Booking.belongsTo(Listing, { foreignKey: 'listingId', targetKey: 'listingId', constraints: false });
+ListingAvailableNight.hasMany(Booking);
+
+// Create a new database if it doesn't exist;
+db.query('CREATE DATABASE IF NOT EXISTS grounded_n_grits;')
+  .then(() => db.query('USE grounded_n_grits'))
+  .then(() => User.sync())
+  .then(() => Listing.sync())
+  .then(() => Booking.sync())
+  .then(() => ListingAvailableNight.sync())
+  .then(() => console.log('Sequelize Sync worked!'))
+  .catch(err => console.log('Oh, no! An Error!', err));
+
+// Export schemas
+exports.User = User;
+exports.Listing = Listing;
+exports.Booking = Booking;
+exports.ListingAvailableNight = ListingAvailableNight;


### PR DESCRIPTION
Completely revamped Sequelize model to more precisely articulate the relationships.

Goal is to unblock the I/O on sync; use non-default keys (i.e. listingId, not listing_id, where listingId is the name of the PK on the table listings, versus listing_id, where listing is the table name and id is the PK).