### PR TITLE
Issue#23 start end filters

### DIFF
--- a/client/src/components/calendar.jsx
+++ b/client/src/components/calendar.jsx
@@ -13,22 +13,72 @@ class Calendar extends React.Component {
     this.state = {
       focusedInput: props.autoFocusEndDate ? 'endDate' : 'startDate',
       startDate: null,
+      startDayMinusOne: null,
+      firstUnavailableNight: null,
       endDate: null,
-      availableNights: this.props.availableNights,
+      // availableNights: this.props.availableNights,
       minimumNights: this.props.minimumNights,
       showInputs: true,
-    };
+    }
 
     this.onDatesChange = this.onDatesChange.bind(this);
     this.onFocusChange = this.onFocusChange.bind(this);
     this.isDayBlocked = this.isDayBlocked.bind(this);
+    this.clearDates = this.clearDates.bind(this)
+    this.findFirstUnavailable = this.findFirstUnavailable.bind(this);
   }
   
+  clearDates () {
+    this.setState({startDate: null, endDate: null});
+    this.onFocusChange(this.state.focusedInput);
+  }
+
+  findFirstUnavailable(startDate) {
+    console.log(`The argument for findFirstUnavailable is -->`, startDate);
+    let startDatePosition = 0
+    for (let i = 0; i < this.props.availableNights.length; i++) {
+      if (startDate.isSame(this.props.availableNights[i].startDate,'day')){
+        startDatePosition = i;
+        break;
+      }
+    }
+
+    let searchDate = startDate.clone()
+    // console.log(`The searchdate starts as --> `, searchDate);
+    console.log(`the startDatePosition is --> `, startDatePosition)
+    for (let j = startDatePosition; j < this.props.availableNights.length; j++) {
+      // for each night in available nights (starting at the index of the start date)
+      // currentNight = availablenights[index].startDate  
+      console.log(`Am I iterating through indexes as expected?`,j)
+      let currentNight = moment(this.props.availableNights[j].startDate);
+      console.log(`currentNight is --> `, currentNight);
+      console.log(`searchDate is --> `, searchDate);
+      if (searchDate.isSame(currentNight, 'day')){
+        console.log(`The days are the same -->`)
+        // console.log(`The searchDate is --> `, searchDate);
+        // console.log(`the currentNight is -->`, currentNight);
+      } else {
+        console.log(`The days are different -->`)
+        // console.log(`The searchDate is --> `, searchDate);
+        // console.log(`the currentNight is -->`, currentNight);
+        this.setState({firstUnavailableNight: searchDate});
+        console.log(`The state is now --> `, this.state);
+        return;
+      }
+      searchDate.add(1, 'days')
+    }
+  }
+
   onDatesChange({ startDate, endDate }) {
+    
     this.setState({
       startDate: startDate,
       endDate: endDate,
+      startDayMinusOne: startDate.clone().add(-1, 'days'),
     })
+
+    this.findFirstUnavailable(startDate)
+
   }
 
 
@@ -40,23 +90,27 @@ class Calendar extends React.Component {
   }
 
   isDayBlocked(selectedDate) {
-    let numberOfAvailableNights = this.props.availableNights.length;
-    for ( let night = 0; night < numberOfAvailableNights; night++) {
-      let currentNight = moment(this.props.availableNights[night].startDate);
-      if (selectedDate.isSame(moment(currentNight), "day")) {
-        return false;
-      }
-      else if (currentNight.isAfter(selectedDate, "day")) {
+    // let numberOfAvailableNights = this.props.availableNights.length;
+    // is the startDate in availablenights?
+    
+
+    if (this.state.startDayMinusOne) {
+      if (selectedDate.isBefore(this.state.startDate, 'day')){
+        // console.log(`the startDay_str is -->`, startDay_str);
+        // console.log(`the startDate is --> `, this.state.startDate);
+        // console.log(`selectedDate that is before start -->`, selectedDate._d);
+        // console.log(`the startMinusOne is --> `, this.state.startDayMinusOne._d);
         return true;
       }
-    } 
-    return true;
+    }
+    // is the night *after* the first unavailable?
   }
 
   render() {
     return (
       <div>        
         <h1> The calendar component </h1>
+        <button onClick={this.clearDates}>Clear Dates</button>
         <DayPickerRangeController
           startDate={this.state.startDate} // momentPropTypes.momentObj or null,
           endDate={this.state.endDate} // momentPropTypes.momentObj or null,

--- a/client/src/components/calendar.jsx
+++ b/client/src/components/calendar.jsx
@@ -1,6 +1,7 @@
 import 'react-dates/initialize';
 import 'react-dates/lib/css/_datepicker.css';
 import React from 'react';
+import moment from 'moment';
 
 import { DateRangePicker, SingleDatePicker, DayPickerRangeController } from 'react-dates';
 
@@ -23,6 +24,9 @@ class Calendar extends React.Component {
       minimumNights: this.props.minimumNights
     };
 
+    this.onDatesChange = this.onDatesChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+    this.isDayBlocked = this.isDayBlocked.bind(this);
 
   }
 
@@ -33,6 +37,7 @@ class Calendar extends React.Component {
     this.setState({
       startDate: startDate,
       endDate: endDate,
+      minimumNights: this.props.minimumNights
     })
   }
 
@@ -40,6 +45,31 @@ class Calendar extends React.Component {
     console.log(`The focused input is ----->`, focusedInput)
     this.setState({ focusedInput })
   }
+
+  isDayBlocked(selectedDate) {
+    console.log(`The selected day from isDayBlocked -->`, selectedDate)
+    let numberOfAvailableNights = this.props.availableNights.length;
+    console.log(`The numberOfAvailableNights is -->`, numberOfAvailableNights)
+    for ( let night = 0; night < numberOfAvailableNights; night++) {
+      let currentNight = moment(this.props.availableNights[night].startDate);
+      console.log(`The current night is --> `, currentNight)
+      if (selectedDate.isSame(moment(currentNight), "day")) {
+        console.log(`the selectedDate --> `, selectedDate);
+        console.log(`Is the same as --> `, currentNight);
+        return true;
+      }
+      else if (currentNight.isAfter(selectedDate, "day")) {
+        console.log(`the currentNight --> `, currentNight);
+        console.log(`Is after the selectedDate --> `, selectedDate);
+        return false;
+      }
+    } 
+    console.log(`the selectedDate -->`, selectedDate)
+    console.log(`is NOT available`)
+    return false;
+
+  }
+  // isDayBlocked: PropTypes.func,
 
   render() {
     console.log(`the props passed to calendar ----> `, this.props)
@@ -59,9 +89,11 @@ class Calendar extends React.Component {
           <DayPickerRangeController
             startDate={this.state.startDate} // momentPropTypes.momentObj or null,
             endDate={this.state.endDate} // momentPropTypes.momentObj or null,
-            onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
+            onDatesChange={this.onDatesChange} // PropTypes.func.isRequired,
             focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-            onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
+            onFocusChange={this.onFocusChange} // PropTypes.func.isRequired,
+            minimumNights={this.state.minimumNights} // PropTypes.number
+            isDayBlocked={this.isDayBlocked}
           />
         </div>
       </div>

--- a/client/src/components/calendar.jsx
+++ b/client/src/components/calendar.jsx
@@ -9,93 +9,66 @@ import { DateRangePicker, SingleDatePicker, DayPickerRangeController } from 'rea
 class Calendar extends React.Component {
   constructor(props) {
     super(props);
-    let focusedInput = null;
-    if (props.autoFocus) {
-      focusedInput = START_DATE;
-    } else if (props.autoFocusEndDate) {
-      focusedInput = END_DATE;
-    }
-
+    
     this.state = {
-      focusedInput,
+      focusedInput: props.autoFocusEndDate ? 'endDate' : 'startDate',
       startDate: null,
       endDate: null,
       availableNights: this.props.availableNights,
-      minimumNights: this.props.minimumNights
+      minimumNights: this.props.minimumNights,
+      showInputs: true,
     };
 
     this.onDatesChange = this.onDatesChange.bind(this);
     this.onFocusChange = this.onFocusChange.bind(this);
     this.isDayBlocked = this.isDayBlocked.bind(this);
-
   }
-
+  
   onDatesChange({ startDate, endDate }) {
-    console.log(`The Date changed, startDate -------> `, startDate)
-    console.log(`The Date changed, endDate -------> `, endDate)
-    // const { stateDateWrapper } = this.props; // Believe this is for internationalization
     this.setState({
       startDate: startDate,
       endDate: endDate,
-      minimumNights: this.props.minimumNights
     })
   }
 
+
   onFocusChange(focusedInput) {
     console.log(`The focused input is ----->`, focusedInput)
-    this.setState({ focusedInput })
+    this.setState({
+      focusedInput: !focusedInput ? "startDate" : focusedInput
+    })
   }
 
   isDayBlocked(selectedDate) {
-    console.log(`The selected day from isDayBlocked -->`, selectedDate)
     let numberOfAvailableNights = this.props.availableNights.length;
-    console.log(`The numberOfAvailableNights is -->`, numberOfAvailableNights)
     for ( let night = 0; night < numberOfAvailableNights; night++) {
       let currentNight = moment(this.props.availableNights[night].startDate);
-      console.log(`The current night is --> `, currentNight)
       if (selectedDate.isSame(moment(currentNight), "day")) {
-        console.log(`the selectedDate --> `, selectedDate);
-        console.log(`Is the same as --> `, currentNight);
-        return true;
-      }
-      else if (currentNight.isAfter(selectedDate, "day")) {
-        console.log(`the currentNight --> `, currentNight);
-        console.log(`Is after the selectedDate --> `, selectedDate);
         return false;
       }
+      else if (currentNight.isAfter(selectedDate, "day")) {
+        return true;
+      }
     } 
-    console.log(`the selectedDate -->`, selectedDate)
-    console.log(`is NOT available`)
-    return false;
-
+    return true;
   }
-  // isDayBlocked: PropTypes.func,
 
   render() {
-    console.log(`the props passed to calendar ----> `, this.props)
     return (
-      <div>
+      <div>        
         <h1> The calendar component </h1>
-        {/* <DateRangePicker 
+        <DayPickerRangeController
           startDate={this.state.startDate} // momentPropTypes.momentObj or null,
-          startDateId="your_unique_start_date_id" // PropTypes.string.isRequired,
           endDate={this.state.endDate} // momentPropTypes.momentObj or null,
-          endDateId="your_unique_end_date_id" // PropTypes.string.isRequired,
-          onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
           focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-          onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
-        /> */}
-        <div>
-          <DayPickerRangeController
-            startDate={this.state.startDate} // momentPropTypes.momentObj or null,
-            endDate={this.state.endDate} // momentPropTypes.momentObj or null,
-            onDatesChange={this.onDatesChange} // PropTypes.func.isRequired,
-            focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
-            onFocusChange={this.onFocusChange} // PropTypes.func.isRequired,
-            minimumNights={this.state.minimumNights} // PropTypes.number
-            isDayBlocked={this.isDayBlocked}
-          />
-        </div>
+          minimumNights={this.state.minimumNights} // PropTypes.number
+          onDatesChange={this.onDatesChange} // PropTypes.func.isRequired,
+          onFocusChange={this.onFocusChange} // PropTypes.func.isRequired,
+          isDayBlocked={this.isDayBlocked}
+          keepOpenOnDateSelect={true}
+          noBorder={true}
+          numberOfMonths={2}
+        />
       </div>
     )
   }

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -17,8 +17,8 @@ class App extends React.Component {
   getAvailableNights(listingId){
     axios.get(`/availableNights/${listingId}`)
     .then( (response) => {
-      console.log(`This is the response of the axios GET: ------> `, response.data);
-      console.log(`This is the response.data of the axios GET: ------> `, response);
+      // console.log(`This is the response of the axios GET: ------> `, response.data);
+      // console.log(`This is the response.data of the axios GET: ------> `, response);
       this.setState({availableNights: response.data})
     })
     .catch( (error) => {

--- a/server/server.js
+++ b/server/server.js
@@ -181,6 +181,7 @@ app.get('/availableNights/:listingId', (request, response) => {
       listingId: request.params.listingId,
       booked: false,
     },
+    order: ['startDate']
   })
     .then(results => response.status(200).send(results))
     .catch(err => response.status(404).send(errorMessage, err));


### PR DESCRIPTION
Fixes #23 
Fixes #24 

![screen shot 2018-11-02 at 8 16 08 pm](https://user-images.githubusercontent.com/39878535/47947567-45cc7a00-dedc-11e8-9d91-a6802e5beb66.png)

![screen shot 2018-11-02 at 8 15 56 pm](https://user-images.githubusercontent.com/39878535/47947568-45cc7a00-dedc-11e8-989e-7268b780f711.png)

We can now select a start and end date and see which nights are available for selecting. Unavailable nights are not selectable. 

Future work will include:
* Adding conditions that prevent selecting an end night that is *after* an unavailable night --> the simplest way to accomplish this seems to be that once a *start* date has been selected, find all dates *before* that day *and* all days *after* the first unavailable night, and mark them all as unavailable. 
* Add a clear nights button/feature


